### PR TITLE
fix for alignment2 on cheri-linux. compiler difference from cheribsd …

### DIFF
--- a/alignment2/baseline-x86-linux/src/main.c
+++ b/alignment2/baseline-x86-linux/src/main.c
@@ -21,7 +21,7 @@ void ** ctest1(void)
 {
 static double a[2048];
 printf("ctest1: pointer-casts requires proper alignment  \n");
-   void *p0 = (void*)&a[1];
+   void *p0 = (void*)&a[0];
   // Pointer p0 is aligned to a 8 byte boundary;
   // type 'void **' requires capability alignment (16 bytes)
   return (void**)p0;

--- a/alignment2/faulty-cheri-linux/README.md
+++ b/alignment2/faulty-cheri-linux/README.md
@@ -25,8 +25,7 @@ src/main.c:41:1: warning: Address of stack memory associated with local variable
 
 
 runtime:
+./build/alignment2 
 ctest1: pointer-casts requires proper alignment  
- .. ctest1, &blah = 0xfffffff7fb30 Passes?? Expected to pass but might be issue in future
-
-
+Bus error (core dumped)
 

--- a/alignment2/faulty-cheri-linux/src/main.c
+++ b/alignment2/faulty-cheri-linux/src/main.c
@@ -21,7 +21,7 @@ void ** ctest1(void)
 {
 static double a[2048];
 printf("ctest1: pointer-casts requires proper alignment  \n");
-   void *p0 = (void*)&a[1];
+   void *p0 = (void*)&a[0];
   // Pointer p0 is aligned to a 8 byte boundary;
   // type 'void **' requires capability alignment (16 bytes)
   return (void**)p0;


### PR DESCRIPTION
…version caused the broken code in faulty to actually fix the issue..