### PR TITLE
146 make testing more robust for llm porting

### DIFF
--- a/alignment1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment1/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment1/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment2/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment2/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment2_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment2_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment2_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment2_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment3/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment3/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment_ardu/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment_ardu/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment_ardu/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/alignment_ardu/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/alignment_ardu/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment_ardu/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/alignment_ardu/test-suite/test-build-ported-cheri-bsd.sh
+++ b/alignment_ardu/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/arduprob/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/arduprob/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/arduprob/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/arduprob/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/arduprob/test-suite/test-build-ported-cheri-bsd.sh
+++ b/arduprob/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/arduprob/test-suite/test-build-ported-cheri-bsd.sh
+++ b/arduprob/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/bndschk/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/bndschk/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/bndschk/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/bndschk/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/bndschk/test-suite/test-build-ported-cheri-bsd.sh
+++ b/bndschk/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/bndschk/test-suite/test-build-ported-cheri-bsd.sh
+++ b/bndschk/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint2/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint2/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capasint_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capasint_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capasint_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capasint_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capcopy/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capcopy/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capcopy/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/capcopy/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/capcopy/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capcopy/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/capcopy/test-suite/test-build-ported-cheri-bsd.sh
+++ b/capcopy/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/code_chksum/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/code_chksum/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/code_chksum/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/code_chksum/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/code_chksum/test-suite/test-build-ported-cheri-bsd.sh
+++ b/code_chksum/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then  
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/code_chksum/test-suite/test-build-ported-cheri-bsd.sh
+++ b/code_chksum/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/overalloc/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/overalloc/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/overalloc/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/overalloc/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/overalloc/test-suite/test-build-ported-cheri-bsd.sh
+++ b/overalloc/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/overalloc/test-suite/test-build-ported-cheri-bsd.sh
+++ b/overalloc/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/pthread0/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/pthread0/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/pthread0/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/pthread0/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/pthread0/test-suite/test-build-ported-cheri-bsd.sh
+++ b/pthread0/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/pthread0/test-suite/test-build-ported-cheri-bsd.sh
+++ b/pthread0/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrbitflags/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrbitflags/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrbitflags/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrbitflags/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrbitflags/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrbitflags/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrbitflags/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrbitflags/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff2/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff2/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiff3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiff3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff3/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiff3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiff3/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiffa0/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiffa0/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiffa0/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiffa0/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiffa0/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiffa0/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiffa0/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiffa0/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiffa1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiffa1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiffa1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrdiffa1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrdiffa1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiffa1/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrdiffa1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrdiffa1/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrszchk/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrszchk/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrszchk/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/ptrszchk/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/ptrszchk/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrszchk/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/ptrszchk/test-suite/test-build-ported-cheri-bsd.sh
+++ b/ptrszchk/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/readplus1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/readplus1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/readplus1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/readplus1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/readplus1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/readplus1/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/readplus1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/readplus1/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/samplealloc/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/samplealloc/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/samplealloc/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/samplealloc/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/samplealloc/test-suite/test-build-ported-cheri-bsd.sh
+++ b/samplealloc/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/samplealloc/test-suite/test-build-ported-cheri-bsd.sh
+++ b/samplealloc/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/sigtest/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/sigtest/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/sigtest/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/sigtest/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/sigtest/test-suite/test-build-ported-cheri-bsd.sh
+++ b/sigtest/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/sigtest/test-suite/test-build-ported-cheri-bsd.sh
+++ b/sigtest/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds1/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds1/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds2/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds2/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds2_cpp/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds2_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds2_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds2_cpp/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds2_cpp/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds3/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds3/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds4/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds4/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds4/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjbnds4/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjbnds4/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds4/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjbnds4/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjbnds4/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjrep/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjrep/test-suite/test-build-faulty-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-faulty-cheri-bsd"
 
 cd ../faulty-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjrep/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/subobjrep/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/subobjrep/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjrep/test-suite/test-build-ported-cheri-bsd.sh
@@ -6,9 +6,21 @@ NAME="$EXAMPLE-ported-cheri-bsd"
 
 cd ../ported-cheri-bsd/
 
-if make clean && make 2>&1 | { [ -t 1 ] && tee -a /dev/tty || cat; }; then 
-    echo "RESULT:  $NAME build success." 
-    exit 0
+BUILD_RESULTS="$(make clean && make 2>&1)"
+STATUS=$?
+
+echo "$BUILD_RESULTS"
+
+if [ "$STATUS" -eq 0 ]; then
+    if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+        echo "RESULT:  $NAME build success." 
+        exit 0
+    else
+        echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+        exit 1
+    fi
 else
     echo "RESULT:  $NAME build failed."
     exit 1

--- a/subobjrep/test-suite/test-build-ported-cheri-bsd.sh
+++ b/subobjrep/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 if [ "$STATUS" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; then
         echo "RESULT:  $NAME build success." 
         exit 0
     else

--- a/warn1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed but generate an integer to ptr cast warning
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced" ; then

--- a/warn1/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn1/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn1/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn1/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn1/test-suite/test-build-ported-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed and generate no integer to ptr cast warnings
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: cast from provenance-free integer type to pointer type will give pointer that can not be dereferenced" ; then

--- a/warn2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -11,6 +11,13 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
 # Build should succeed but generate an integer to ptr cast warning
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: comparison between pointer and integer" ; then

--- a/warn2/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn2/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn2/test-suite/test-build-ported-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed and generate no integer to ptr cast warning
 if [ "$status" -eq 0 ]; then
     if ! printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: comparison between pointer and integer" ; then

--- a/warn2/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn2/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap"; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed but generate warning
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: binary expression on capability types" ; then

--- a/warn3/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn3/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn3/test-suite/test-build-ported-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed and generate no integer to ptr cast warning
 if [ "$status" -eq 0 ]; then
     if ! printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: binary expression on capability types" ; then

--- a/warn3/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn3/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn4/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn4/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn4/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn4/test-suite/test-build-faulty-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed but generate warning
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: expression which evaluates to zero treated as a null pointer constant" ; then

--- a/warn4/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn4/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn4/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn4/test-suite/test-build-ported-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed and not generate warning
 if [ "$status" -eq 0 ]; then
     if ! printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: expression which evaluates to zero treated as a null pointer constant" ; then

--- a/warn5/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn5/test-suite/test-build-faulty-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed but generate warning
 if [ "$status" -eq 0 ]; then
     if printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: binary expression on capability types" ; then

--- a/warn5/test-suite/test-build-faulty-cheri-bsd.sh
+++ b/warn5/test-suite/test-build-faulty-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn5/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn5/test-suite/test-build-ported-cheri-bsd.sh
@@ -13,8 +13,7 @@ echo "$BUILD_RESULTS"
 
 # Check if purecap flags were used
 if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
-    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" ; } ; then
     echo "RESULT:  $NAME build failed.  Purecap not used during compile"
     exit 1
 fi

--- a/warn5/test-suite/test-build-ported-cheri-bsd.sh
+++ b/warn5/test-suite/test-build-ported-cheri-bsd.sh
@@ -11,6 +11,14 @@ status=$?
 
 echo "$BUILD_RESULTS"
 
+# Check if purecap flags were used
+if ! { printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-march=morello" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "-mabi=purecap" \
+    && printf '%s\n' "$BUILD_RESULTS" | grep -Fq -- "--target=aarch64-linux-musl_purecap" ; } ; then
+    echo "RESULT:  $NAME build failed.  Purecap not used during compile"
+    exit 1
+fi
+
 # Build should succeed and not generate warning
 if [ "$status" -eq 0 ]; then
     if ! printf '%s\n' "$BUILD_RESULTS" | grep -Fq "warning: binary expression on capability types" ; then


### PR DESCRIPTION
Completing test updates to check for purecap flags during ported (and faulty) build tests.